### PR TITLE
empty textbox when editing About Text

### DIFF
--- a/spec/acceptance/hacker_spec.rb
+++ b/spec/acceptance/hacker_spec.rb
@@ -5,7 +5,7 @@ feature "Hackers" do
   scenario "can register" do
 
     visit '/signup'
-    
+
     fill_in "Email", :with => "steve@example.com"
     fill_in "Username", :with => "steve"
     fill_in "Password", :with => "foobar"
@@ -107,4 +107,13 @@ feature "Hackers" do
     Hacker.authenticate("alindeman", "abc123").should be
   end
 
+  scenario "see their current about text in the textarea when editing their profile" do
+    @tobi = Factory(:hacker, :username => "tobi", :about => "loremipsum")
+    log_in @tobi
+    visit "/hackers/tobi"
+
+    page.find_field('hacker[about]').value.should == "loremipsum"
+  end
+
 end
+

--- a/views/hackers/show.haml
+++ b/views/hackers/show.haml
@@ -14,7 +14,7 @@
       %a{:href => "/programs/#{@hacker.username}/#{program.slug}"}= program.title
 
 %hr
-- if logged_in? 
+- if logged_in?
   - if @hacker.username != current_user.username
     %a{:href => "/messages/new/to/#{@hacker.username}" }= "Send #{@hacker.username} a message"
     - if current_user.following? @hacker
@@ -47,7 +47,7 @@
       %form{:action => "/hackers/update", :method => "POST"}
         %label{:for => "hacker[about]"} About Me
         %br
-        %textarea{:name => "hacker[about]", :rows => 10, :cols => 40}
+        %textarea{:name => "hacker[about]", :rows => 10, :cols => 40}=@hacker.about
         %br
         %input{:type => "submit", :value => "Update About"}
     %br
@@ -62,3 +62,4 @@
         $('#account_settings').toggle("blinds");
       });
     });
+


### PR DESCRIPTION
The about text wasn't shown in the textbox on the profile page when editing it (so after clicking "Change my settings"). As I wanted to change mine I found this to be annoying as I had to scroll up and copy my old about text when I just wanted to add something. So I fixed it :-)

I added a spec as well, however I am a bit discontent with the spec as I wrote page.find_field('hacker[about]').value.should == "loremipsum" and think that page.find_field('hacker[about]').should have_content "loremipsum" should work, but well it has been some time since I have used RSpec/capybara a lot.
