### PR TITLE
Choose an answer feature

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -11,4 +11,8 @@ class QuestionsController < InheritedController
     @answer = Answer.new
     show!
   end
+
+  def update
+    params[:question][:solution_id] != @question.solution_id ? update!(:notice => "Okay! We've selected that answer") : update!
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,9 +3,12 @@ class Question
 
   key :title, String
   key :description, String
+  key :solution_id, ObjectId
 
   belongs_to :user
   many :answers
+  
+  one :answer, :in => :solution_id
 
   validates_presence_of :title, :description
 

--- a/app/views/answers/_list.html.haml
+++ b/app/views/answers/_list.html.haml
@@ -8,3 +8,7 @@
     = link_to 'Edit', edit_question_answer_path(@question, list)
   - if can? :destroy, list
     = link_to 'Delete', question_answer_path(@question, list), :confirm => 'Are you sure?', :method => :delete
+  - if can? :update, @question
+    = simple_form_for(@question, :url => question_path(@question)) do |f|
+      = f.hidden_field :solution_id, :value => list.id
+      = f.button :submit, :value => "This answer is correct", :class => "primary btn"

--- a/app/views/questions/_list.html.haml
+++ b/app/views/questions/_list.html.haml
@@ -1,4 +1,4 @@
-%tr.item
+%tr.item{:id=>list.id}
   %td= list.title
   %td= list.description
   %td= link_to "Show", resource_path(list)

--- a/features/answers.feature
+++ b/features/answers.feature
@@ -17,3 +17,12 @@ Feature: CRUD actions for question
     Then I should see "Answer Posted!"
     And I should see "My Answer" within ".answers"
     And I should see "Answered by test" within ".answer"
+
+  Scenario: Select an answer
+    Given I have created a question with title "My Title" and description "My Description"
+    And that someone has provided an answer for my question
+    And I am on the questions index
+    And I follow "Show" for my question
+    And I press "This answer is correct"
+    Then I should see "Okay! We've selected that answer"
+    

--- a/features/step_definitions/answer_steps.rb
+++ b/features/step_definitions/answer_steps.rb
@@ -1,0 +1,5 @@
+Given /^that someone has provided an answer for my question$/ do
+  other_user =  Fabricate(:user)
+  other_user.save!
+  @question.answers.build(:description => "Some solution", :user => other_user).save!
+end

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -1,8 +1,12 @@
 Given /^I have created a question with title "([^"]*)" and description "([^"]*)"$/ do |title, description|
-  @user.questions.build(:title => "#{title}", :description =>"#{description}").save!
+  @question = @user.questions.build(:title => "#{title}", :description =>"#{description}")
+  @question.save!
 end
 
 Given /^there are existing questions$/ do
   2.times{Fabricate(:question)}
 end
 
+When /^(?:|I )follow "([^"]*)" for my question$/ do |link|
+  find("##{@question.id}").click_link(link)
+end


### PR DESCRIPTION
I was unsure abt a couple items. I mapped the chosen answer within Question as solution_id. I also added 
  one :answer, :in => :solution_id
in addition to the existing
  many :answers

Is the one declaration needed for referential integrity? If not pls take it out. It worked without issue.

For now I assumed that if user can update the question they can select an answer for it. Fair enough?

Changes backed up by Scenario: Select an answer in answers.feature.
