### PR TITLE
Username uniqueness validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@ class User
     :message => "Make your username from letters, numbers, underscores('_'), and dots('.')."
   validates_length_of :username, :in => (1..32),
     :message => "Your username needs at least 1 character but no more than 32."
+  validates_uniqueness_of :username,
+    :message => "User name has been taken already. Please try another"
 
   def to_param
     self.username

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -3,7 +3,7 @@ SimpleForm.setup do |config|
   # Components used by the form builder to generate a complete input. You can remove
   # any of them, change the order, or even add your own components to the stack.
   # config.components = [ :placeholder, :label_input, :hint, :error ]
-  config.components = [ :placeholder, :label_input, :hint ]
+  config.components = [ :placeholder, :label_input, :hint, :error ]
 
   # Default tag used on hints.
   # config.hint_tag = :span

--- a/features/signup.feature
+++ b/features/signup.feature
@@ -5,3 +5,7 @@ Feature: Sign up for an account
   Scenario: Create an account via the signup form
     When I register a new account
     Then I should be logged in with my new account
+
+  Scenario: Try to sign up using existing user name
+    When I register a duplicate account
+    Then I should see validation errors

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -1,17 +1,31 @@
-When /^I register a new account$/ do
-  @user_info = {:username => "username", :password => "password", :email => "test@example.com"}
-
+def register_user(user)
   visit new_user_registration_path
-
-  fill_in("Username", :with => @user_info[:username])
-  fill_in("Email", :with => @user_info[:email])
-  fill_in("Password", :with => @user_info[:password])
-  fill_in("Password confirmation", :with => @user_info[:password])
+  fill_in("Username", :with => user[:username])
+  fill_in("Email", :with => user[:email])
+  fill_in("Password", :with => user[:password])
+  fill_in("Password confirmation", :with => user[:password])
 
   click_button "Sign up"
 end
 
+When /^I register a new account$/ do
+  @new_user = {:username => "username", :password => "password", :email => "test@example.com"}
+  register_user @new_user
+end
+
+When /^I register a duplicate account$/ do
+  @existing_user = User.create!(username:              "existing_user",
+                                email:                 "existing_user@example.com",
+                                password:              "foobar",
+                                password_confirmation: "foobar")
+  register_user @existing_user
+end
+
 When /^I should be logged in with my new account$/ do
   page.should have_content("You have signed up successfully")
-  page.should have_content(@user_info[:username])
+  page.should have_content(@new_user[:username])
+end
+
+Then /^I should see validation errors$/ do
+  page.should have_selector(".error_notification")
 end


### PR DESCRIPTION
Fixes #116

Any idea why error info was turned off in the simple_form initializer? I've turned it back on globally - don't think it'll be an issue.
