### PR TITLE
Restrict access to MailerController actions

### DIFF
--- a/app/controllers/mailer_controller.rb
+++ b/app/controllers/mailer_controller.rb
@@ -1,4 +1,6 @@
 class MailerController < ApplicationController
+  load_and_authorize_resource class: Message
+
   def new
     @users = Array(params[:user])
     @emails = User.where(:username => @users).all.map(&:email)


### PR DESCRIPTION
Here's a fix for issue #175 - a small change, but I did need to alter the MailerController's controller specs so they could handle the different contexts of being accessed by a moderator, normal user, or guest.

Let me know if you have concerns with the way I tested this (or anything else). Thanks for your help!
